### PR TITLE
Add instructions option to speech request

### DIFF
--- a/async-openai/src/types/audio.rs
+++ b/async-openai/src/types/audio.rs
@@ -192,6 +192,11 @@ pub struct CreateSpeechRequest {
     /// Previews of the voices are available in the [Text to speech guide](https://platform.openai.com/docs/guides/text-to-speech#voice-options).
     pub voice: Voice,
 
+    /// Control the voice of your generated audio with additional instructions.
+    /// Does not work with `tts-1` or `tts-1-hd`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub instructions: Option<String>,
+
     /// The format to audio in. Supported formats are `mp3`, `opus`, `aac`, `flac`, `wav`, and `pcm`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub response_format: Option<SpeechResponseFormat>,

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -11440,6 +11440,10 @@ components:
                     description: The voice to use when generating the audio. Supported voices are `alloy`, `echo`, `fable`, `onyx`, `nova`, and `shimmer`. Previews of the voices are available in the [Text to speech guide](/docs/guides/text-to-speech/voice-options).
                     type: string
                     enum: ["alloy", "echo", "fable", "onyx", "nova", "shimmer"]
+                instructions:
+                    description: |
+                        Control the voice of your generated audio with additional instructions. Does not work with `tts-1` or `tts-1-hd`.
+                    type: string
                 response_format:
                     description: "The format to audio in. Supported formats are `mp3`, `opus`, `aac`, `flac`, `wav`, and `pcm`."
                     default: "mp3"


### PR DESCRIPTION
## Summary
- support the new `instructions` parameter for text-to-speech
- document this field in the OpenAPI spec

## Testing
- `cargo test --workspace --quiet` *(fails: failed to download crates)*